### PR TITLE
bring in chatterbot for normal conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 
 .idea
 
+# the training result for the chatterbot
+db.sqlite3
+
 # C extensions
 *.so
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gTTS
 pyaudio
 bs4
 colorprint
+chatterbot

--- a/src/Bot.py
+++ b/src/Bot.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from chatterbot import ChatBot
+from chatterbot.trainers import ListTrainer
+
+from dict import conversations
+from utils import speak
+
+class Bot:
+    def __init__(self):
+        self.bot = ChatBot(
+            "Zakas",
+            logic_adapters= [
+                {'import_path': 'chatterbot.logic.BestMatch'},
+                {'import_path': 'chatterbot.logic.TimeLogicAdapter'},
+                {'import_path': 'chatterbot.logic.MathematicalEvaluation'},
+                {'import_path': 'chatterbot.logic.LowConfidenceAdapter',
+                 'threshold': 0.60,
+                 'default_response': 'I am sorry, but I do not understand.'}
+            ],
+            # input_adapter="chatterbot.input.TerminalAdapter",
+            # output_adapter="chatterbot.output.TerminalAdapter"
+        )
+
+        self.bot.set_trainer(ListTrainer)
+
+        for c in conversations:
+            self.bot.train(c)
+
+    def respondTo(self, words):
+        response = self.bot.get_response(words)
+        speak(str(response))
+
+if __name__ == '__main__':
+    b = Bot()
+    b.respondTo("How old are you?")

--- a/src/dict.py
+++ b/src/dict.py
@@ -2,8 +2,36 @@
 # Note that this only restores the hard-coded basic responses
 # For more advanced responses, please refer to other files
 
-dict = {
-    "how are you": "I'm fine",
-    "how old are you": "I'm kind of a baby as you may know",
-    "marriage": "Sorry, I don't feel like talking about my personal life"
-}
+greetings = [
+    'How are you?',
+    'I am pretty good.',
+    'That is good to hear.',
+    'Thank you.',
+    'You are welcome.',
+]
+
+age = [
+    'How old are you?',
+    'I don\'t really know. I felt like I was born yesterday.'
+]
+
+profile = [
+    'Who are you?',
+    'Zakas. Nice to meet you.'
+]
+
+privacy = [
+    'Are you married?',
+    'Sorry, I don\'t want to talk about it.',
+    'So do you have a boyfriend?',
+    'Not yet, it\'s hard for me to figure out what love is.',
+    'Hope you find your true love sometime',
+    'Thank you. I mean it.'
+]
+
+conversations = [
+    greetings,
+    age,
+    profile,
+    privacy
+]

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,4 +52,5 @@ def greeting():
     speak("Good {}, {}. What can I do for you?".format(phase, username))
 
 def goodbye():
-    speak("Take care. Have a nice day.")
+    phase = "day" if datetime.datetime.now().hour < 18 else "night"
+    speak("Take care. Have a good {}".format(phase))

--- a/src/zakas.py
+++ b/src/zakas.py
@@ -1,27 +1,18 @@
 from getch import getch
-from time import ctime
 
 from handlers.Youtube import Youtube
 from handlers.Google import Google
-from dict import dict
+from chat import Bot
 from utils import *
 
 
 class Zakas:
     def __init__(self):
+        self.bot = Bot()
         pass
 
     def respond(self, data):
-        # loop through the basic / hard-coded responses
-        for keyword, res in dict.items():
-            if keyword in data:
-                speak(res)
-                return
-
         # todo: move these to a separated handler utility file
-        if "time" in data:
-            speak(ctime())
-            return
 
         if "where is" in data:
             data = data.split(" ")
@@ -40,9 +31,7 @@ class Zakas:
             g.search()
             return
 
-        # if voice msg not comprehended
-        speak("I'm truly sorry. Didn't get what you meant.")
-
+        self.bot.respondTo(data)
         return
 
 


### PR DESCRIPTION
> ChatterBot is a Python library that makes it easy to generate automated responses to a user’s input. ChatterBot uses a selection of machine learning algorithms to produce different types of responses. This makes it easy for developers to create chat bots and automate conversations with users.

But after going through the poorly-written document, I still haven't figured out a good way to have a well-controlled method to configure the chatterbot, and make the conversation go more fluent and natural.

The two possible reasons are:
1. lack of conversation samples
2. wrong way of configuration when initiating the bot

But I think we could test more, to see how it grows in scale. I recommend testing it in `Bot.py`, rather than calling `zakas` directly. He is tired and needs some rest. :)